### PR TITLE
fix: normalize scoped SimpleX chat refs

### DIFF
--- a/src/simplex-commands.test.ts
+++ b/src/simplex-commands.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, test } from "vitest";
 import {
   buildDeleteChatItemCommand,
   buildReceiveFileCommand,
@@ -67,14 +67,17 @@ describe("simplex commands", () => {
     ).toBe('/_send #1 json [{"msgContent":{"type":"text","text":"hello group"}}]');
   });
 
-  it("normalizes scoped SimpleX direct refs in delete command", () => {
-    expect(
-      buildDeleteChatItemCommand({
-        chatRef: "simplex:4",
-        chatItemIds: [12],
-      })
-    ).toBe("/_delete item @4 12 broadcast");
-  });
+  test.each(["simplex:4", "simplex:contact:4", "simplex:user:4", "simplex:member:4"])(
+    "normalizes scoped SimpleX direct ref %s in delete command",
+    (chatRef) => {
+      expect(
+        buildDeleteChatItemCommand({
+          chatRef,
+          chatItemIds: [12],
+        })
+      ).toBe("/_delete item @4 12 broadcast");
+    }
+  );
 
   it("emits raw JSON payload in update group profile command", () => {
     expect(

--- a/src/simplex-commands.ts
+++ b/src/simplex-commands.ts
@@ -64,25 +64,23 @@ function normalizeSimplexChatRef(raw: string): string {
   if (!withoutPrefix) {
     return withoutPrefix;
   }
-  if (withoutPrefix.startsWith("@") || withoutPrefix.startsWith("#")) {
-    return withoutPrefix;
+  if (withoutPrefix.startsWith("#") || withoutPrefix.toLowerCase().startsWith("group:")) {
+    return normalizeGroupRef(withoutPrefix);
+  }
+  if (withoutPrefix.startsWith("@")) {
+    return normalizeContactRef(withoutPrefix);
   }
 
   const lowered = withoutPrefix.toLowerCase();
-  if (lowered.startsWith("group:")) {
-    const id = withoutPrefix.slice("group:".length).trim();
-    return id ? `#${id}` : withoutPrefix;
-  }
   if (
     lowered.startsWith("contact:") ||
     lowered.startsWith("user:") ||
     lowered.startsWith("member:")
   ) {
-    const id = withoutPrefix.slice(withoutPrefix.indexOf(":") + 1).trim();
-    return id ? `@${id}` : withoutPrefix;
+    return normalizeContactRef(withoutPrefix);
   }
 
-  return `@${withoutPrefix}`;
+  return normalizeContactRef(withoutPrefix);
 }
 
 function normalizeChatRefToken(value: string): string {


### PR DESCRIPTION
## Summary
Fix outbound SimpleX command building when OpenClaw provides scoped chat refs such as `simplex:group:1` or `simplex:4`.
Previously, outbound command builders expected raw CLI refs like `#1` or `@4` and rejected scoped refs with errors like:
`invalid SimpleX chat ref: simplex:group:1`
## What changed
- add scoped SimpleX ref normalization in `normalizeChatRefToken()`
- normalize `simplex:group:1` to `#1`
- normalize direct refs like `simplex:4`, `contact:4`, `user:4`, and `member:4` to `@4`
- add tests covering normalized group and direct refs in outbound commands
## Why this matters
Other parts of the plugin already understand scoped SimpleX refs, but outbound command construction still assumed everything had already been converted to raw CLI tokens.
This patch makes outbound send/delete/update/reaction handling consistent with the rest of the plugin and fixes failed queued or recovered deliveries for group chats.
## Verification
- `pnpm test`
- `pnpm typecheck`