### PR TITLE
fix: align plugin id with npm package name to prevent infinite loop

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -363,7 +363,7 @@ function registerSimplexGatewayMethods(api: OpenClawPluginApi): void {
 }
 
 export default defineChannelPluginEntry({
-  id: "simplex",
+  id: "openclaw-simplex",
   name: "SimpleX",
   description: "SimpleX Chat channel plugin via CLI",
   plugin: simplexPlugin,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "simplex",
+  "id": "openclaw-simplex",
   "kind": "channel",
   "channels": ["simplex"],
   "name": "SimpleX",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "extensions": ["./dist/index.js"],
     "setupEntry": "./dist/setup-entry.js",
     "channel": {
-      "id": "simplex",
+      "id": "openclaw-simplex",
       "label": "SimpleX",
       "selectionLabel": "SimpleX (CLI)",
       "docsPath": "/channels/simplex",


### PR DESCRIPTION
## Summary

- Aligns the plugin `id` field from `"simplex"` to `"openclaw-simplex"` in all three locations (`index.ts`, `openclaw.plugin.json`, `package.json`)

## Problem

In OpenClaw `2026.3.24`, the gateway derives the expected plugin ID from the npm package name (`@dangoldbj/openclaw-simplex` -> `openclaw-simplex`). When the plugin declares `id: "simplex"`, the mismatch triggers a config validation warning which calls `getConsoleSettings()` -> `loadConfig()` -> `validate()` -> `warn()` in an infinite recursive loop. This consumes 100% CPU and prevents the gateway from binding to port 18789.

The root cause is in the gateway's config validation (`env-D1ktUnAV.js`), which calls `console.warn` for the mismatch, and `console.warn` is patched to go through the config/logging system, creating the recursion.

## Fix

Changed `id` from `"simplex"` to `"openclaw-simplex"` in:
1. `index.ts:366` - `defineChannelPluginEntry({ id: ... })`
2. `openclaw.plugin.json` - `"id"` field
3. `package.json:69` - `openclaw.channel.id` field

This makes the declared ID match what the gateway derives from the scoped package name, preventing the mismatch warning and the resulting infinite loop.

## Testing

- Deployed to a production OpenClaw gateway instance running `2026.3.24`
- Gateway starts cleanly with no log spam, binds port 18789, health endpoint returns `{"ok":true,"status":"live"}`
- SimpleX plugin activates and connects successfully
